### PR TITLE
Fix group use example

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,11 +402,7 @@ use some\namespace\ClassB;
 use some\namespace\ClassC as C;
 
 // PHP 7+ code
-use parent\child\{
-    ClassA,
-    ClassB,
-    ClassC as C
-};
+use some\namespace\{ClassA, ClassB, ClassC as C};
 ```
 
 RFC: [Group use Declarations](https://wiki.php.net/rfc/group_use_declarations)


### PR DESCRIPTION
^^ RFC author here:
- use `some\namespace`, not `parent\child`, to match previous code
- the new syntax is intended to be a one liner whenever possible (that's how it's commonly used by other languages that have this feature)

Would be nice to have examples with functions and constants too:

``` php
    use function some\namespace\{fn_a, fn_b, fn_c};
    use const some\namespace\{ConstA, ConstB, ConstC};
```

Thanks for maintaining this guide.
