### PR TITLE
Strict mode is script-based, not file-based

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,12 +140,11 @@ function sumOfInts(int ...$ints)
 var_dump(sumOfInts(2, '3', 4.1)); // int(9)
 ```
 
-To enable strict mode, a single `declare()` directive must be placed at the top
-of the file. This means that the strictness of typing for scalars is configured
-on a per-file basis. This directive not only affects the type declarations of
-parameters, but also a function's return type (see [Return Type
-Declarations](#return-type-declarations)), built-in PHP functions, and
-functions from loaded extensions.
+To enable strict mode, a `declare()` directive must be the first statement of
+a script. The strict mode will apply to the entire script. This directive not
+only affects the type declarations of parameters, but also a function's return
+type (see [Return Type Declarations](#return-type-declarations)), built-in PHP
+functions, and functions from loaded extensions.
 
 If the type-check fails, then a `TypeError` exception (see [Exceptions in the
 Engine](#exceptions-in-the-engine)) is thrown. The only leniency present in


### PR DESCRIPTION
An example to prove it:

``` php
<?php
// foo.php

declare(strict_types=1);

require('bar.php');

foo('1');
```

``` php
<?php
// bar.php

function foo(int $var) {}
```

```
$ php -v
PHP 7.0.0-1~dotdeb+8.1 (cli) NTS 
Copyright (c) 1997-2015 The PHP Group
Zend Engine v3.0.0, Copyright (c) 1998-2015 Zend Technologies

$ php foo.php
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to foo() must be of the
type integer, string given, called in /path/foo.php on line 8 and defined in
/path/bar.php:4
Stack trace:
#0 /path/foo.php(8): foo('1')
#1 {main}
  thrown in /path/bar.php on line 4
```
